### PR TITLE
Fixed HEAD crashes on /version

### DIFF
--- a/filetracker/servers/base.py
+++ b/filetracker/servers/base.py
@@ -29,7 +29,8 @@ class Server(object):
                 _body_iter = self.__call__(environ, start_response)
                 # Server implementations should return closeable iterators
                 # from handle_GET to avoid resource leaks.
-                _body_iter.close()
+                if hasattr(_body_iter, 'close'):
+                    _body_iter.close()
 
                 return []
             else:


### PR DESCRIPTION
Currently, /version returns a simple list of bytes to be sent, but such a list doesn't have a `.close()` method, so the request fails.
I've added a check that makes sure the iterator is closeable before closing it.

An alternative would be to wrap the list in some fake closeable class. I'm open to discussion on that.