### PR TITLE
Change date format passed to touch command

### DIFF
--- a/filetracker/servers/storage.py
+++ b/filetracker/servers/storage.py
@@ -27,7 +27,6 @@ from __future__ import division
 from __future__ import print_function
 
 import contextlib
-import email.utils
 import errno
 import fcntl
 import gevent
@@ -481,7 +480,7 @@ def _makedirs(path):
 
 def lutime(path, time):
     if six.PY2:
-        t = email.utils.formatdate(time)
+        t = time.isoformat()
         if subprocess.call(['touch', '-c', '-h', '-d', t, path]) != 0:
             raise RuntimeError
     else:


### PR DESCRIPTION
GNU touch accepts pretty much any format, while BSD touch is only happy with ISO format.

This commit is motivated by my attempts to run oioioi on FreeBSD.