### PR TITLE
SIO-2391 Package bsddb3 version 6.2.8 crushes docker image build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages = find_packages(),
 
     install_requires = [
-        'bsddb3',
+        'bsddb3==6.2.7',
         'flup6',
         'gunicorn==19.8.1',
         'gevent==1.3.1',


### PR DESCRIPTION
Fixed by setting version constrain to 6.2.7
[Link to jira issue](https://jira.sio2project.mimuw.edu.pl/browse/SIO-2391)