### PR TITLE
Fix tox config and address warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist
 
 .eggs
 .tox
+.coverage*
 .pytest_cache
 .idea
 

--- a/filetracker/servers/run.py
+++ b/filetracker/servers/run.py
@@ -80,7 +80,7 @@ _DEFAULT_LOG_CONFIG_JSON = """
 
 
 def strip_margin(text):
-    return re.sub('\n[ \t]*\|', '\n', text)
+    return re.sub(r'\n[ \t]*\|', '\n', text)
 
 
 def main(args=None):

--- a/filetracker/tests/interaction_test.py
+++ b/filetracker/tests/interaction_test.py
@@ -172,11 +172,11 @@ class InteractionTest(unittest.TestCase):
             self.client.get_stream('/older.txt@1')
 
     def test_get_nonexistent_should_404(self):
-        with self.assertRaisesRegexp(FiletrackerError, "404"):
+        with self.assertRaisesRegex(FiletrackerError, "404"):
             self.client.get_stream('/nonexistent.txt')
 
     def test_delete_nonexistent_should_404(self):
-        with self.assertRaisesRegexp(FiletrackerError, "404"):
+        with self.assertRaisesRegex(FiletrackerError, "404"):
             self.client.delete_file('/nonexistent.txt')
 
     def test_delete_should_remove_file_and_dir(self):
@@ -197,7 +197,7 @@ class InteractionTest(unittest.TestCase):
                     ),
                 )
 
-        with self.assertRaisesRegexp(FiletrackerError, "404"):
+        with self.assertRaisesRegex(FiletrackerError, "404"):
             self.client.get_stream('/dir/del.txt')
 
 

--- a/filetracker/tests/migration_test.py
+++ b/filetracker/tests/migration_test.py
@@ -118,7 +118,7 @@ class MigrationTest(unittest.TestCase):
         )
 
     def test_file_version_of_not_existent_file_should_return_404(self):
-        with self.assertRaisesRegexp(FiletrackerError, "404"):
+        with self.assertRaisesRegex(FiletrackerError, "404"):
             self.client.get_stream('/nonexistent.txt')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
-envlist=py27,py37
+envlist = py38,py39
 
 [testenv]
-deps=pytest
-     pytest-cov
+extras = server
+deps = pytest
+       pytest-cov
+setenv =
+# Needed for systems with an AGPL-licensed Berkeley DB
+         YES_I_HAVE_THE_RIGHT_TO_USE_THIS_BERKELEY_DB_VERSION = 1
 commands = pytest --cov=./ {posargs}


### PR DESCRIPTION
The python versions in tox.ini are the same as in the pytest workflow.

The warnings that show up when running tox are:
```
filetracker/servers/run.py:83
  /src/ups-ft/filetracker/servers/run.py:83: DeprecationWarning: invalid escape sequence \|
    return re.sub('\n[ \t]*\|', '\n', text)

filetracker/tests/interaction_test.py::InteractionTest::test_delete_nonexistent_should_404
  /src/ups-ft/filetracker/tests/interaction_test.py:179: DeprecationWarning: Please use assertRaisesRegex instead.
    with self.assertRaisesRegexp(FiletrackerError, "404"):
...
```